### PR TITLE
Add baseline 2stroke ECU sketch for ESP32

### DIFF
--- a/2stroke-ecu.ino
+++ b/2stroke-ecu.ino
@@ -1,0 +1,84 @@
+#include <Arduino.h>
+#include "env_types.h"
+#include "env_delta.h"
+#include "auto_reach.h"
+#include "drag_controller.h"
+#include "safety.h"
+#include "hardware_io.h"
+
+using namespace ecu;
+
+// ---------- User Presets (edit here) ----------
+static ProfileParams PROF = {
+  Profile::RACE_200,   // profile
+  200.0f,              // goal_distance_m
+  150.0f,              // v_target_top_kmh (0 = adapt later)
+  0.90f,               // frontload_gain
+  0.60f,               // frontload_window_pc
+  0.025f,              // plateau_fuel_pc (+2.5%)
+  0.4f                 // plateau_ign_deg (+0.4°)
+};
+
+static AutoReachParams ARP = {
+  true, 150.0f, 1.5f,   // use_v_target, v_target_kmh, v_margin_kmh
+  0.03f, 0.15f,         // dvds_min, dvdt_min
+  25, 300,              // win_m, win_ms (simple use in detector)
+  450, 25.0f            // min_push_ms, min_push_m
+};
+
+static DragTuning TUNE = {
+  0.12f, 0.7f,          // max_push_fuel, max_push_ign_deg
+  100, 80,              // ae_tps_ms, ae_rpm_ms
+  25.0f, 1500.0f        // dTPS_thr_ps, dRPM_thr_ps
+};
+
+static EDParams EDP = { 0.03f, 0.06f, -0.01f, 0.15f, 0.5f };
+static SafetyLimits SAFE = { 780.0f, 110.0f, 85.0f };
+
+// ---------- System objects ----------
+static EnvInputs IN;
+static Outputs   OUT;
+static EnvDelta      ED;
+static AutoReach     AR;
+static DragController DC;
+
+// Base map placeholders (replace with your real base calculations)
+static float BASE_FUEL_MS = 3.0f;
+static float BASE_IGN_DEG = 18.0f;
+
+void setup(){
+  io_init();
+  log_begin(115200); // logs will print only if serial is really attached
+
+  ED.begin(EDP);
+  AR.begin(ARP);
+  DC.begin(PROF, ARP, TUNE);
+  DC.attachModules(&ED, &AR);
+  DC.setVtargetInit(PROF.v_target_top_kmh);
+
+  // Arm distance origin
+  DC.arm(0.0f);
+
+  log_printf("ECU READY: profile=%d goal=%.0fm vTgt=%.0fkmh\n", (int)PROF.profile, PROF.goal_distance_m, PROF.v_target_top_kmh);
+}
+
+void loop(){
+  // 1) Read sensors (mock or real inside hardware_io)
+  io_read(IN);
+
+  // 2) Compute control outputs
+  OUT = {1.0f, 0.0f};
+  DC.tick(IN, OUT);
+  applySafety(IN, OUT, SAFE);
+
+  // 3) Combine with base map
+  float fuel_ms = baseFuelMsEstimate(IN, BASE_FUEL_MS) * OUT.fuel_mul;
+  float ign_deg = baseIgnDegEstimate(IN, BASE_IGN_DEG) + OUT.ign_add_deg;
+
+  // 4) Drive actuators
+  applyInjection(fuel_ms);
+  applyIgnition(ign_deg);
+
+  // 5) HUD/log (prints only if serial attached)
+  log_status(IN, OUT, DC.state());
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# 2stroke-ecu

--- a/auto_reach.h
+++ b/auto_reach.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <Arduino.h>
+#include "env_types.h"
+
+namespace ecu {
+
+struct AutoReachParams{
+  bool use_v_target=true; float v_target_kmh=0; float v_margin_kmh=1.5f;
+  float dvds_min=0.03f; float dvdt_min=0.15f; uint16_t win_m=25; uint16_t win_ms=300;
+  uint16_t min_push_ms=450; float min_push_m=25.0f;
+};
+
+class AutoReach{
+public:
+  void begin(const AutoReachParams&p){ P=p; reset(); }
+  void reset(){ reached_=false; t0_=millis(); s0_=0; }
+  void arm(float s0){ s0_=s0; t0_=millis(); reached_=false; }
+  void setVtarget(float kmh){ v_tgt_kmh_=kmh; }
+  bool reached() const { return reached_; }
+  float s_reach() const { return s_reach_; }
+
+  inline void sample(const EnvInputs& in){
+    if(reached_) return;
+    uint32_t dt=millis()-t0_; float ds=in.distance_m - s0_;
+    bool minTime = dt >= P.min_push_ms; bool minDist = ds >= P.min_push_m;
+    bool hit=false;
+    if(P.use_v_target && v_tgt_kmh_>0.1f){ float vm=P.v_margin_kmh*(1000.f/3600.f);
+      hit = in.speed_mps >= (v_tgt_kmh_*(1000.f/3600.f) - vm); }
+    bool weak = (in.dv_ds <= P.dvds_min) && (in.dv_dt <= P.dvdt_min);
+    if(minTime && minDist && (hit || weak)){ reached_=true; s_reach_=in.distance_m; }
+  }
+private:
+  AutoReachParams P{}; bool reached_=false; float s_reach_=0; uint32_t t0_=0; float s0_=0; float v_tgt_kmh_=0;
+};
+
+} // namespace ecu

--- a/drag_controller.h
+++ b/drag_controller.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <Arduino.h>
+#include "env_types.h"
+#include "env_delta.h"
+#include "auto_reach.h"
+
+namespace ecu {
+
+enum class DragState : uint8_t { ARM=0, LAUNCH, PUSH, HOLD, FINISH };
+
+struct DragTuning{ float max_push_fuel=0.12f, max_push_ign_deg=0.7f; uint16_t ae_tps_ms=100, ae_rpm_ms=80; float dTPS_thr_ps=25.0f, dRPM_thr_ps=1500.0f; };
+
+class DragController{
+public:
+  void begin(const ProfileParams& prof, const AutoReachParams& arP, const DragTuning& tune){ prof_=prof; tune_=tune; ar_.begin(arP); state_=DragState::ARM; }
+  void attachModules(EnvDelta* ed, AutoReach* ar){ ed_=ed; external_ar_=ar; }
+  void arm(float s0){ state_=DragState::ARM; ar_.arm(s0); ae_tps_until_=0; ae_rpm_until_=0; }
+  void setVtargetInit(float kmh){ v_tgt_kmh_=kmh; }
+  DragState state() const { return state_; }
+
+  inline void tick(const EnvInputs& in, Outputs& out){
+    out.fuel_mul=1.0f; out.ign_add_deg=0.0f;
+    if(ed_) ed_->compute(in, out.fuel_mul, out.ign_add_deg);
+
+    switch(state_){
+      case DragState::ARM:
+        if(in.tps_pc>=90.0f) state_=DragState::LAUNCH; break;
+      case DragState::LAUNCH:
+        state_=DragState::PUSH; break;
+      case DragState::PUSH: {
+        uint32_t now=millis();
+        if(in.dTPS_dt>tune_.dTPS_thr_ps) ae_tps_until_=now+tune_.ae_tps_ms;
+        if(in.dRPM_dt>tune_.dRPM_thr_ps) ae_rpm_until_=now+tune_.ae_rpm_ms;
+        float extra=0.0f; if(now<ae_tps_until_) extra+=0.15f; if(now<ae_rpm_until_) extra+=0.08f;
+
+        float bump=0.0f;
+        if(v_tgt_kmh_>0.1f){
+          float vt=v_tgt_kmh_*(1000.f/3600.f);
+          if(vt>0.1f){ float ev=(vt - in.speed_mps)/vt; if(ev>0){
+            float env=1.0f; if(prof_.goal_distance_m>1.0f){ float x=in.distance_m/(prof_.goal_distance_m*max(0.1f,prof_.frontload_window_pc)); env=constrain(1.0f-x,0.0f,1.0f);} bump=ev*prof_.frontload_gain*env; }}
+        }
+        bump=constrain(bump,0.0f,tune_.max_push_fuel);
+
+        out.fuel_mul *= (1.0f + bump + extra);
+        if(tune_.max_push_fuel>1e-6f)
+          out.ign_add_deg += tune_.max_push_ign_deg * (bump / tune_.max_push_fuel);
+
+        ar_.setVtarget(v_tgt_kmh_);
+        ar_.sample(in);
+        if(ar_.reached()) state_=DragState::HOLD;
+      } break;
+      case DragState::HOLD:
+        out.fuel_mul *= (1.0f + prof_.plateau_fuel_pc);
+        out.ign_add_deg += prof_.plateau_ign_deg;
+        if(prof_.goal_distance_m>1.0f && in.distance_m>=prof_.goal_distance_m) state_=DragState::FINISH;
+        break;
+      case DragState::FINISH: break;
+    }
+  }
+private:
+  ProfileParams prof_{}; DragTuning tune_{}; AutoReach ar_{}; EnvDelta* ed_=nullptr; AutoReach* external_ar_=nullptr; DragState state_=DragState::ARM; uint32_t ae_tps_until_=0, ae_rpm_until_=0; float v_tgt_kmh_=0.0f;
+};
+
+} // namespace ecu

--- a/env_delta.h
+++ b/env_delta.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <Arduino.h>
+#include "env_types.h"
+
+namespace ecu {
+
+struct EDParams { float iat_per10c_pc=0.03f, baro_per10kpa_pc=0.06f, rh_per20pc_pc=-0.01f, max_fuel_pc=0.15f, max_ign_deg=0.5f; };
+
+class EnvDelta{
+public:
+  void begin(const EDParams&p){ P=p; }
+  inline void compute(const EnvInputs& in, float& fuel_mul, float& ign_add_deg) const {
+    float fuel_pc=0.0f;
+    fuel_pc += P.iat_per10c_pc   * ((25.0f - in.iat_c)/10.0f);
+    fuel_pc += P.baro_per10kpa_pc* ((in.baro_kpa - 101.0f)/10.0f);
+    fuel_pc += P.rh_per20pc_pc   * ((in.rh_pc - 40.0f)/20.0f);
+    fuel_pc = constrain(fuel_pc, -P.max_fuel_pc, P.max_fuel_pc);
+    fuel_mul *= (1.0f + fuel_pc);
+    float ign=0.0f;
+    if(in.iat_c<20 && in.baro_kpa>101) ign+=0.3f; // dense cool air
+    if(in.iat_c>35 || in.baro_kpa<95)  ign-=0.3f; // hot / thin air
+    ign = constrain(ign, -P.max_ign_deg, P.max_ign_deg);
+    ign_add_deg += ign;
+  }
+private: EDParams P{}; };
+
+} // namespace ecu

--- a/env_types.h
+++ b/env_types.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <Arduino.h>
+
+namespace ecu {
+
+enum class Profile : uint8_t { HARIAN=0, RACE_200, RACE_300, RACE_400, RACE_500, RACE_1000 };
+
+struct ProfileParams{
+  Profile profile; float goal_distance_m; float v_target_top_kmh;
+  float frontload_gain; float frontload_window_pc; float plateau_fuel_pc; float plateau_ign_deg;
+};
+
+struct EnvInputs{
+  // Vehicle kinematics (from GPS/IMU fusion or stubbed)
+  float speed_mps=0; float distance_m=0; float dv_dt=0; float dv_ds=0;
+  // Engine
+  int rpm=0; float dRPM_dt=0; float tps_pc=0; float dTPS_dt=0;
+  // Thermal & supply
+  float egt_c=0; float cht_c=0; float fuel_rail_bar=3.0f; float duty_inj_pc=0; float batt_v=12.5f;
+  // Environment
+  float iat_c=25; float baro_kpa=101; float rh_pc=40;
+};
+
+struct Outputs{ float fuel_mul=1.0f; float ign_add_deg=0.0f; };
+
+} // namespace ecu

--- a/hardware_io.cpp
+++ b/hardware_io.cpp
@@ -1,0 +1,75 @@
+#include <Arduino.h>
+#include <stdarg.h>
+#include <math.h>
+#include "env_types.h"
+#include "drag_controller.h"
+#include "hardware_io.h"  // ensure declarations match implementations
+
+namespace ecu {
+static uint32_t t0=0; static bool serial_ready=false; static uint32_t last_log=0;
+
+void log_begin(uint32_t baud){
+  Serial.begin(baud);
+  delay(150); // allow serial port to settle
+  serial_ready = Serial && (Serial.availableForWrite()>0); // log only if host present
+}
+
+void log_printf(const char* fmt, ...){
+  if(!serial_ready) return;
+  char buf[196];
+  va_list ap; va_start(ap, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_end(ap);
+  Serial.print(buf);
+}
+
+void io_init(){ t0=millis(); }
+
+void io_read(EnvInputs& in){
+  // SIMPLE SIMULATOR so you can see state transitions without sensors
+  static uint32_t last=millis();
+  uint32_t now=millis();
+  float dt=(now-last)/1000.0f; if(dt<=0) dt=0.01f; last=now;
+
+  // Assume WOT after 300 ms
+  if((now - t0) > 300) in.tps_pc = 100.0f; else in.tps_pc = 0.0f;
+
+  // Mock RPM rise (asymptotically approaches ~10k)
+  float t=(now - t0)/1000.0f;
+  int rpm_prev=in.rpm;
+  in.rpm = 3000 + (int)(7000.0f*(1.0f - expf(-t*0.9f)));
+  in.dRPM_dt = (in.rpm - rpm_prev) / max(0.001f, dt);
+
+  // Mock speed & distance
+  float v_prev=in.speed_mps;
+  in.speed_mps = 2.0f + 40.0f*(1.0f - expf(-t*0.8f));
+  in.dv_dt = (in.speed_mps - v_prev)/max(0.001f, dt);
+  in.distance_m += in.speed_mps * dt;
+  in.dv_ds = (in.speed_mps - v_prev)/max(0.01f, in.speed_mps*dt);
+
+  // Thermal & supply (safe nominal)
+  in.egt_c = 720.0f + 10.0f*sinf(t*1.3f);
+  in.cht_c = 95.0f;
+  in.fuel_rail_bar = 3.2f;
+  in.duty_inj_pc = 60.0f;
+  in.batt_v = 12.4f;
+
+  // Environment (change to test ED)
+  in.iat_c = 30.0f; in.baro_kpa=100.0f; in.rh_pc=50.0f;
+}
+
+float baseFuelMsEstimate(const EnvInputs& in, float baseMs){ (void)in; return baseMs; }
+float baseIgnDegEstimate(const EnvInputs& in, float baseDeg){ (void)in; return baseDeg; }
+
+void applyInjection(float fuel_ms){ (void)fuel_ms; /* hook injector driver here */ }
+void applyIgnition(float ign_deg){ (void)ign_deg; /* hook CDI/TCI timing here */ }
+
+void log_status(const EnvInputs& in, const Outputs& out, ecu::DragState st){
+  if(!serial_ready) return;
+  if(millis()-last_log<200) return;
+  last_log=millis();
+  Serial.printf("st=%d v=%.1fkmh s=%.1fm rpm=%d fuel×=%.3f ign+=%.2f EGT=%.0f CHT=%.0f\n",
+    (int)st, in.speed_mps*3.6f, in.distance_m, in.rpm, out.fuel_mul, out.ign_add_deg, in.egt_c, in.cht_c);
+}
+
+} // namespace ecu

--- a/hardware_io.h
+++ b/hardware_io.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <Arduino.h>
+#include "env_types.h"
+#include "drag_controller.h"
+
+// Minimal I/O stubs so sketch compiles and can simulate motion
+namespace ecu {
+void io_init();
+void io_read(EnvInputs& in);
+float baseFuelMsEstimate(const EnvInputs& in, float baseMs);
+float baseIgnDegEstimate(const EnvInputs& in, float baseDeg);
+void applyInjection(float fuel_ms);
+void applyIgnition(float ign_deg);
+
+// logging helpers (print only if serial attached)
+void log_begin(uint32_t baud);
+void log_printf(const char* fmt, ...);
+void log_status(const EnvInputs& in, const Outputs& out, ecu::DragState st);
+}

--- a/safety.h
+++ b/safety.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <Arduino.h>
+#include "env_types.h"
+
+namespace ecu {
+struct SafetyLimits{ float egt_soft_c=780.0f, cht_soft_c=110.0f, duty_max_pc=85.0f; };
+inline void applySafety(const EnvInputs& in, Outputs& out, const SafetyLimits& L){
+  if(in.egt_c > L.egt_soft_c){ out.fuel_mul *= 1.05f; out.ign_add_deg -= 1.0f; }
+  if(in.cht_c > L.cht_soft_c){ out.fuel_mul *= 1.05f; out.ign_add_deg -= 1.0f; }
+  if(in.duty_inj_pc > L.duty_max_pc){ /* clamp injector PW in driver if needed */ }
+}
+} // namespace ecu


### PR DESCRIPTION
## Summary
- Implement baseline drag-race ECU sketch and headers for ESP32
- Include environment delta, auto-reach, drag controller, safety, and stub I/O simulator
- Logging enabled only when host serial connection is detected

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 2stroke-ecu.ino` *(fails: Platform 'esp32:esp32' not found: platform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bc2642b883309148df21d04212a0